### PR TITLE
Add author's tests.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,11 +1,27 @@
-mkdir build
-cd build
+:: cmd
 
-cmake ^
-	-G "NMake Makefiles" ^
-	-DCLI11_BUILD_TESTS=OFF ^
-	-DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
-	-DCLI11_BUILD_EXAMPLES=OFF ^
-	%SRC_DIR%
+:: Isolate the build.
+mkdir Build
+cd Build
+if errorlevel 1 exit 1
 
-nmake install
+:: Generate the build files.
+cmake .. -G"Ninja" %CMAKE_ARGS% ^
+      -DCLI11_BUILD_TESTS=ON ^
+      -DCLI11_BUILD_EXAMPLES=OFF ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release
+
+
+:: Build and install.
+ninja install
+if errorlevel 1 exit 1
+
+
+:: Perform tests.
+ninja test
+if errorlevel 1 exit 1
+
+:: Error free exit .
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,12 +1,20 @@
-mkdir build
-cd build
+#!/bin/bash
 
-cmake \
-    -DCMAKE_INSTALL_PREFIX=$PREFIX \
-    -DCLI11_BUILD_TESTS=OFF \
-    -DCLI11_BUILD_EXAMPLES=OFF \
-    -DCMAKE_INSTALL_LIBDIR=lib \
-    ${CMAKE_ARGS} \
-    $SRC_DIR
+# Isolate the build.
+mkdir -p Build
+cd Build || exit 1
 
-make install
+# Generate the build files.
+cmake .. -G"Ninja" ${CMAKE_ARGS} \
+      -DCLI11_BUILD_TESTS=ON \
+      -DCLI11_BUILD_EXAMPLES=OFF \
+      -DCMAKE_PREFIX_PATH=$PREFIX \
+      -DCMAKE_INSTALL_PREFIX=$PREFIX \
+      -DCMAKE_BUILD_TYPE=Release
+
+# Build and install.
+ninja install || exit 1
+
+
+# Perform tests.
+ninja test || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,5 +16,11 @@ cmake .. -G"Ninja" ${CMAKE_ARGS} \
 ninja install || exit 1
 
 
+# Exit early for s390x since `libboost` is not available.
+if [ "${target_platform}" == 'linux-aarch64' ]; then
+    exit 0
+fi
+
+
 # Perform tests.
 ninja test || exit 1

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,9 +4,17 @@
 mkdir -p Build
 cd Build || exit 1
 
+# Don't build tests for `s390x` since boost is missing.
+if [ "${target_platform}" == 'linux-s390x' ]; then
+    build_tests=OFF
+else
+    build_tests=ON
+fi
+
+
 # Generate the build files.
 cmake .. -G"Ninja" ${CMAKE_ARGS} \
-      -DCLI11_BUILD_TESTS=ON \
+      -DCLI11_BUILD_TESTS=${build_tests} \
       -DCLI11_BUILD_EXAMPLES=OFF \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
@@ -17,7 +25,7 @@ ninja install || exit 1
 
 
 # Exit early for s390x since `libboost` is not available.
-if [ "${target_platform}" == 'linux-aarch64' ]; then
+if [ "${target_platform}" == 'linux-s390x' ]; then
     exit 0
 fi
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,8 @@
 {% set name = "cli11" %}
 {% set version = "2.1.2" %}
+{% set sha_hash = "26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb" %}
+{% set build_number = "0" %}
+
 
 package:
   name: {{ name|lower }}
@@ -7,20 +10,24 @@ package:
 
 source:
   url: https://github.com/CLIUtils/CLI11/archive/v{{ version }}.tar.gz
-  sha256: 26291377e892ba0e5b4972cdfd4a2ab3bf53af8dac1f4ea8fe0d1376b625c8cb
+  sha256: {{ sha_hash }}
 
 build:
-  number: 0
+  number: {{ build_number }}
 
 requirements:
   build:
-    - cmake
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
-    - make  # [unix]
+    - cmake
+    - ninja
+  host:
+    - libboost >=1.61
 
 test:
+  # NOTE: Author's tests are run from the build scripts in all architectures.
   commands:
+    # Insure files are installed to the correct location.
     - test -f $PREFIX/include/CLI/CLI.hpp  # [unix]
     - if exist %LIBRARY_INC%\CLI\CLI.hpp (exit 0) else (exit 1)  # [win]
 
@@ -44,8 +51,9 @@ about:
     Releases for details for current and past releases. Also see the
     Version 1.0 post, Version 1.3 post, or Version 1.6 post for more
     information.
-  doc_url: https://cliutils.github.io/CLI11/book
   dev_url: https://github.com/CLIUtils/CLI11
+  doc_url: https://cliutils.github.io/CLI11/book
+  doc_src_url: https://github.com/CLIUtils/CLI11/tree/main/docs
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,11 @@ requirements:
     - cmake
     - ninja
   host:
-    - libboost >=1.61
+    #  libboost is not available in s390x yet. When it is, update `build.sh` to ensure autor's tests are run.
+    - libboost >=1.61  # [not s390x]
 
 test:
-  # NOTE: Author's tests are run from the build scripts in all architectures.
+  # NOTE: Author's tests are run from the build scripts in all architectures (except s390x!).
   commands:
     # Insure files are installed to the correct location.
     - test -f $PREFIX/include/CLI/CLI.hpp  # [unix]


### PR DESCRIPTION
# Changes

Changes:
- Initial fork from conda-forge.
- Update build files:
  - Prefer ninja to NMake/make.
  - Enable author's testing.

# Review Information

## Source

https://github.com/CLIUtils/CLI11

## Upstream Changes

Initial fork, no version change.

## Issues

https://github.com/CLIUtils/CLI11/issues

Nothing that looks like it should stop inclusion.


## Pins and Requireds

Build time testing requires libboost > 1.61 in host file, otherwise this is a header only library.

## Testing

CLI11 tests are exercised as part of the build process. Additional tests help ensure the package is built.

`s390x` lacks the `libboost` package. I evaluated the effort to adding it and decided I could not justify it.


# Closing Comments

This package is required for libmambapy. I can think of no reason not to accept it.


